### PR TITLE
add support for enum tuples

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ future features:
         c: u32,
     }
 
+    #[derive(Deserialize, Debug, PartialEq)]
+    enum Command {
+        Q,
+        Help,
+        Size(usize, usize),
+        Color(u8),
+    }
+
     fn main() {
         let s = "1 2 3";
 
@@ -37,5 +45,9 @@ future features:
 
         let c: Triple = serde_scan::from_str(s).unwrap();
         assert_eq!(c, Triple { a: 1, b: 2, c: 3 });
+
+        let s = "Size 1 2";
+        let size = serde_scan::from_str(s).unwrap();
+        assert_eq!(c, Command::Size(1, 2));
     }
 ```

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -345,16 +345,16 @@ impl<'de, 'a> VariantAccess<'de> for Sequence<'de, 'a> {
     }
 
 
-    fn newtype_variant_seed<T>(self, _seed: T) -> Result<T::Value, Self::Error>
+    fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value, Self::Error>
         where T: de::DeserializeSeed<'de>
     {
-        Err(ScanError::NS("newtype enum variants"))
+        seed.deserialize(&mut *self.de)
     }
 
-    fn tuple_variant<V>(self, _len: usize, _visitor: V) -> Result<V::Value, Self::Error>
+    fn tuple_variant<V>(self, _len: usize, visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor<'de>
     {
-        Err(ScanError::NS("tuple enum variants"))
+        de::Deserializer::deserialize_seq(self.de, visitor)
     }
 
     fn struct_variant<V>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,6 +172,23 @@ mod tests {
     }
 
     #[test]
+    fn enum_tuple() {
+        #[derive(Deserialize, Debug, PartialEq)]
+        #[serde(rename_all = "snake_case")]
+        enum EnumTuple {
+            Variant(i32),
+            Tuple(String, String, usize),
+        }
+
+        // this might work in the future
+        let a: EnumTuple = from_str("variant 1").unwrap();
+        let b: EnumTuple = from_str("tuple two three 4").unwrap();
+
+        assert_eq!(a, EnumTuple::Variant(1));
+        assert_eq!(b, EnumTuple::Tuple("two".to_string(), "three".to_string(), 4));
+    }
+
+    #[test]
     fn byte_bufs() {
         // maybe: add support for 0x, 0o, 0b
         let bytes: Vec<u8> = from_str("0 1 2 255").unwrap();
@@ -187,21 +204,15 @@ mod tests {
         #[derive(Deserialize, Debug, PartialEq)]
         #[serde(rename_all = "snake_case")]
         enum Bad {
-            Bad(i32),
-            ReallyBad(String, String),
-            EvenWorse {
+            StructVariant {
                 a: f64,
                 b: f64,
             },
         }
 
         // this might work in the future
-        let a: Result<Bad, _> = from_str("bad 1");
-        let b: Result<Bad, _> = from_str("really_bad two three");
-        let c: Result<Bad, _> = from_str("even_worse 0.4 0.5");
+        let c: Result<Bad, _> = from_str("struct_variant 0.4 0.5");
 
-        assert!(a.is_err());
-        assert!(b.is_err());
         assert!(c.is_err());
 
         #[derive(Deserialize, Debug, PartialEq)]


### PR DESCRIPTION
Not sure if the crate is still alive but this adds support for enum tuples.
This is useful when you must parse commands with variable length depending on the first item.